### PR TITLE
Add options to logs s3

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,16 @@ func main() {
 			Usage:  "s3 path prefix (optional)",
 			EnvVar: "S3_PREFIX",
 		},
+		cli.StringFlag{
+			Name:   "s3-endpoint",
+			Usage:  "s3 endpoint (optional)",
+			EnvVar: "S3_ENDPOINT",
+		},
+		cli.BoolFlag{
+			Name:   "s3-path-style",
+			Usage:  "s3 path style (optional)",
+			EnvVar: "S3_PATH_STYLE",
+		},
 		cli.BoolTFlag{
 			Name:   "debug",
 			Usage:  "enable debug mode",
@@ -343,9 +353,12 @@ func main() {
 					return err
 				}
 
-				bucket := c.String("s3-bucket")
-				prefix := c.String("s3-prefix")
-				return migrate.MigrateLogsS3(source, bucket, prefix)
+				return migrate.MigrateLogsS3(
+					source,
+					c.GlobalString("s3-bucket"),
+					c.GlobalString("s3-prefix"),
+					c.GlobalString("s3-endpoint"),
+					c.GlobalBool("s3-path-style"))
 			},
 		},
 		{

--- a/migrate/logs.go
+++ b/migrate/logs.go
@@ -117,7 +117,11 @@ func MigrateLogsS3(source *sql.DB, bucket, prefix, endpoint string, pathStyle bo
 		}
 		_, err = uploader.Upload(input)
 		if err != nil {
-			logrus.WithError(err).Errorln("migration failed")
+			logrus.WithFields(logrus.Fields{
+				"proc_id": logsV0.ProcID,
+				"step_id": stepV0.ID,
+				"bucket":  bucket,
+			}).WithError(err).Errorln("migration failed")
 			return err
 		}
 	}


### PR DESCRIPTION
Add command line options "s3-endpoint" and "s3-path-style" .

* drone/drone#2610
* drone/drone#2600

~And fix the bug that it is failed to read  "s3-bucket" and "s3-prefix" ( Change `String` to `GlobalString` ) .~ It has been resolved by #14 so I have canceled this line.