### PR TITLE
Migrate logs to S3 from the middle

### DIFF
--- a/main.go
+++ b/main.go
@@ -343,9 +343,19 @@ func main() {
 					return err
 				}
 
-				bucket := c.String("s3-bucket")
-				prefix := c.String("s3-prefix")
-				return migrate.MigrateLogsS3(source, bucket, prefix)
+				target, err := sql.Open(
+					c.GlobalString("target-database-driver"),
+					c.GlobalString("target-database-datasource"),
+				)
+
+				if err != nil {
+					return err
+				}
+
+				return migrate.MigrateLogsS3(
+					source, target,
+					c.GlobalString("s3-bucket"),
+					c.GlobalString("s3-prefix"))
 			},
 		},
 		{

--- a/migrate/db/mysql/ddl_gen.go
+++ b/migrate/db/mysql/ddl_gen.go
@@ -124,6 +124,14 @@ var migrations = []struct {
 		name: "create-table-org-secrets",
 		stmt: createTableOrgSecrets,
 	},
+	{
+		name: "create-table-last-migrated-log-id",
+		stmt: createTableLastMigratedLogID,
+	},
+	{
+		name: "create-record-last-migrated-log-id",
+		stmt: createRecordLastMigratedLogID,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -576,4 +584,23 @@ CREATE TABLE IF NOT EXISTS orgsecrets (
 ,secret_pull_request_push BOOLEAN
 ,UNIQUE(secret_namespace, secret_name)
 );
+`
+
+//
+// 013_create_table_last_migrated_log_id.sql
+//
+
+var createTableLastMigratedLogID = `
+CREATE TABLE IF NOT EXISTS last_migrated_log_id (
+ id     INTEGER PRIMARY KEY
+,log_id INTEGER
+);
+`
+
+//
+// 014_create_record_last_migrated_log_id.sql
+//
+
+var createRecordLastMigratedLogID = `
+INSERT IGNORE INTO last_migrated_log_id (id, log_id) VALUES (1, -1);
 `

--- a/migrate/db/postgres/ddl_gen.go
+++ b/migrate/db/postgres/ddl_gen.go
@@ -120,6 +120,14 @@ var migrations = []struct {
 		name: "create-table-org-secrets",
 		stmt: createTableOrgSecrets,
 	},
+	{
+		name: "create-table-last-migrated-log-id",
+		stmt: createTableLastMigratedLogID,
+	},
+	{
+		name: "create-record-last-migrated-log-id",
+		stmt: createRecordLastMigratedLogID,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -554,4 +562,24 @@ CREATE TABLE IF NOT EXISTS orgsecrets (
 ,secret_pull_request_push BOOLEAN
 ,UNIQUE(secret_namespace, secret_name)
 );
+`
+
+//
+// 013_create_table_last_migrated_log_id.sql
+//
+
+var createTableLastMigratedLogID = `
+CREATE TABLE IF NOT EXISTS last_migrated_log_id (
+ id     INTEGER PRIMARY KEY
+,log_id INTEGER
+);
+`
+
+//
+// 014_create_record_last_migrated_log_id.sql
+//
+
+var createRecordLastMigratedLogID = `
+INSERT INTO last_migrated_log_id (id, log_id) VALUES (1, -1)
+ON CONFLICT DO NOTHING;
 `

--- a/migrate/db/sqlite/ddl_gen.go
+++ b/migrate/db/sqlite/ddl_gen.go
@@ -120,6 +120,14 @@ var migrations = []struct {
 		name: "create-table-org-secrets",
 		stmt: createTableOrgSecrets,
 	},
+	{
+		name: "create-table-last-migrated-log-id",
+		stmt: createTableLastMigratedLogID,
+	},
+	{
+		name: "create-record-last-migrated-log-id",
+		stmt: createRecordLastMigratedLogID,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -556,4 +564,23 @@ CREATE TABLE IF NOT EXISTS orgsecrets (
 ,secret_pull_request_push BOOLEAN
 ,UNIQUE(secret_namespace, secret_name)
 );
+`
+
+//
+// 013_create_table_last_migrated_log_id.sql
+//
+
+var createTableLastMigratedLogID = `
+CREATE TABLE IF NOT EXISTS last_migrated_log_id (
+ id     INTEGER PRIMARY KEY
+,log_id INTEGER
+);
+`
+
+//
+// 014_create_record_last_migrated_log_id.sql
+//
+
+var createRecordLastMigratedLogID = `
+INSERT OR IGNORE INTO last_migrated_log_id (id, log_id) VALUES (1, -1);
 `

--- a/migrate/steps.go
+++ b/migrate/steps.go
@@ -86,7 +86,23 @@ WHERE proc_ppid != 0
   AND repo_user_id > 0
 `
 
+const stepListFilterByIDQuery = `
+SELECT procs.*
+FROM procs
+INNER JOIN builds ON procs.proc_build_id = builds.build_id
+INNER JOIN repos ON builds.build_repo_id = repos.repo_id
+WHERE proc_ppid != 0
+  AND repo_user_id > 0
+  AND proc_id > ?
+ORDER BY proc_id
+`
+
 const updateStepSeq = `
 ALTER SEQUENCE steps_step_id_seq
 RESTART WITH %d
+`
+
+const lastMigratedLogIDQuery = `
+SELECT log_id FROM last_migrated_log_id
+WHERE id = 1
 `

--- a/migrate/types.go
+++ b/migrate/types.go
@@ -296,6 +296,12 @@ type (
 		Token        string `meddler:"registry_token"`
 	}
 
+	// LastMigratedLogID is a last migrated log id.
+	LastMigratedLogID struct {
+		ID    int64 `meddler:"id,pk"`
+		LogID int64 `meddler:"log_id"`
+	}
+
 	// DockerConfig defines required attributes from Docker registry credentials.
 	DockerConfig struct {
 		AuthConfigs map[string]AuthConfig `json:"auths"`


### PR DESCRIPTION
When migrating logs to S3, save the last migrated log id at DB and in the next time migrate logs from the next id.
Before we stop the Drone for its upgrade, we can migrate almost logs online so we can really decrease the downtime for the upgrade.
It takes a very long time to migrate logs to S3 if the logs table is huge, so this feature is very important.