### PR TITLE
Fix API token from the GitHub access token to Drone API token

### DIFF
--- a/migrate/repos.go
+++ b/migrate/repos.go
@@ -199,8 +199,7 @@ func ActivateRepositories(db *sql.DB, client drone.Client) error {
 		client.SetClient(config.Client(
 			oauth2.NoContext,
 			&oauth2.Token{
-				AccessToken:  user.Token,
-				RefreshToken: user.Refresh,
+				AccessToken: user.Hash,
 			},
 		))
 


### PR DESCRIPTION
Close https://discourse.drone.io/t/invalid-api-token-is-passed-in-drone-migrate-activate-repos/5067

User.Token is the user's GitHub access token.
drone.Client is a Drone's API client and it requires Drone's API token,
but User.Token is passed.
So it is failed to authenticate the user.

```
level=error msg="activation failed" error="client error 401: {\"message\":\"Unauthorized\"}\n"
```

So I fix to pass User.Hash to the drone.Client istead of User.Token.