### PR TITLE
limit repoActivateQuery only to originally activa repositories

### DIFF
--- a/migrate/repos.go
+++ b/migrate/repos.go
@@ -243,6 +243,7 @@ WHERE repo_id = %d
 const repoActivateQuery = `
 SELECT *
 FROM repos
+WHERE repo_active = 1
 `
 
 const updateRepoSeq = `

--- a/migrate/repos.go
+++ b/migrate/repos.go
@@ -181,6 +181,10 @@ func ActivateRepositories(db *sql.DB, client drone.Client) error {
 		log := logrus.WithFields(logrus.Fields{
 			"repo": repo.Slug,
 		})
+		if !repo.Active {
+			// https://discourse.drone.io/t/drone-migrates-repoactivatequery-is-invalid/5156
+			continue
+		}
 
 		log.Debugln("activating repository")
 
@@ -243,7 +247,6 @@ WHERE repo_id = %d
 const repoActivateQuery = `
 SELECT *
 FROM repos
-WHERE repo_active = 1
 `
 
 const updateRepoSeq = `


### PR DESCRIPTION
Close https://discourse.drone.io/t/drone-migrates-repoactivatequery-is-invalid/5156 .

The command `activate-repos` tries to activate the result of `repoActivateQuery` but the result includes originally inactive repositories.
The command `activate-repos` should activate only originally active repositories.

https://github.com/drone/drone-migrate/blob/v1.1.2/migrate/repos.go#L243-L246