### PR TITLE
Fix Registry Migration

### DIFF
--- a/migrate/registries.go
+++ b/migrate/registries.go
@@ -72,14 +72,14 @@ func MigrateRegistries(source, target *sql.DB) error {
 			continue
 		}
 
-		secretV1 := &SecretV1{
+		registryV1 := &RegistryV1{
 			RepoID:      repoV1.ID,
 			Name:        ".dockerconfigjson",
 			Data:        string(result),
 			PullRequest: true,
 		}
 
-		if err := meddler.Insert(tx, "secrets", secretV1); err != nil {
+		if err := meddler.Insert(tx, "secrets", registryV1); err != nil {
 			log.WithError(err).Errorln("migration failed")
 			return err
 		}

--- a/migrate/types.go
+++ b/migrate/types.go
@@ -295,6 +295,16 @@ type (
 		Password     string `meddler:"registry_password"`
 		Token        string `meddler:"registry_token"`
 	}
+	
+	// RegistryV1 is a Drone 1.x registry -- note that in 1.x these are stored in the secrets table, hence the similar format
+	RegistryV1 struct {
+		ID              int64  `meddler:"secret_id,pk"`
+		RepoID          int64  `meddler:"secret_repo_id"`
+		Name            string `meddler:"secret_name"`
+		Data            string `meddler:"secret_data"`
+		PullRequest     bool   `meddler:"secret_pull_request"`
+		PullRequestPush bool   `meddler:"secret_pull_request_push"`
+	}
 
 	// DockerConfig defines required attributes from Docker registry credentials.
 	DockerConfig struct {


### PR DESCRIPTION
Currrently migrating registries doesn't work as expected as the meddler library was passing in a `secret_id` of `0` for each registry secret created during the migration process, since the id isn't explicitly set for the new registry secrets. 

This fixes this issue by adding a second struct, identical in format to `SecretV1`, but with the `ID` noted as a primary key. By doing this, meddler doesn't insert a zero-value for a new registry secret and leans on the auto-increment feature for the column to automatically set the ID.